### PR TITLE
implemented TTL update on item access

### DIFF
--- a/tcache.go
+++ b/tcache.go
@@ -325,7 +325,7 @@ func (c *Cache[K, V]) SetWithTTL(key K, value V, ttl time.Duration) {
 			newItem = &Item[K, V]{value: value, key: key, timer: timer, onWatch: item.Value.(*Item[K, V]).onWatch}
 		}
 	} else {
-		newItem = &Item[K, V]{value: value, key: key, timer: timer}
+		newItem = &Item[K, V]{value: value, key: key, timer: timer, ttl: ttl}
 	}
 
 	c.items[key] = c.list.PushFront(newItem)


### PR DESCRIPTION
## TTL update on item access

- added `ttl    time.Duration` for accessing time of items since `time.Timer` doesn't expose that
- call **Refresh** on every **Get**

_**Discovered Bug**:_
I didn't handle this since its not related to this PR, but calling `cache.Set()` on the same key panics

`cache.Set("key", 123)`
`cache.Set("key", 123) // <- this causes a panic` 

